### PR TITLE
Puppet 4 compatability

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,0 @@
-name    'jbussdieker-daemontools'
-source  'git@github.com:jbussdieker/puppet-daemontools.git'
-author  'Joshua B. Bussdieker'
-summary 'Daemontools Module'
-version '0.0.3'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,7 +2,7 @@ class daemontools::config {
 
   file {'/etc/service':
     ensure  => directory,
-    mode    => 0755,
+    mode    => '0755',
     owner   => root,
     group   => root,
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,10 +1,10 @@
 class daemontools::config {
 
   file {'/etc/service':
-    ensure  => directory,
-    mode    => '0755',
-    owner   => root,
-    group   => root,
+    ensure => directory,
+    mode   => '0755',
+    owner  => root,
+    group  => root,
   }
 
 }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -6,14 +6,6 @@ class daemontools::package {
 
   package {'daemontools-run':
     ensure  => present,
-    require => Package['daemontools'],
-    notify  => Exec['daemontools-start'],
+    require => Package['daemontools']
   }
-
-  exec {'daemontools-start':
-    command     => "/usr/bin/sudo bash -cf '/usr/bin/svscanboot &'",
-    refreshonly => true,
-    require     => Package['daemontools'],
-  }
-
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -55,7 +55,7 @@ define daemontools::service(
 
   file {"/etc/${name}/log/run":
     ensure  => present,
-    mode    => 0755,
+    mode    => '0755',
     content => template("daemontools/log.erb"),
     require => File["/etc/${name}/log"],
     notify  => Service[$name],
@@ -63,7 +63,7 @@ define daemontools::service(
 
   file {"/etc/${name}/run":
     ensure  => present,
-    mode    => 0755,
+    mode    => '0755',
     content => $service_content,
     require => File["/etc/${name}"],
     notify  => Service[$name],

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,10 +1,10 @@
 define daemontools::service(
-	$ensure="running",
-	$logpath = '',
-	$service_script = '',
-	$command = '',
-	$logfiles = 100,
-	$logsize = 16777215,
+  $ensure='running',
+  $logpath = '',
+  $service_script = '',
+  $command = '',
+  $logfiles = 100,
+  $logsize = 16777215,
 ) {
 
   include daemontools
@@ -56,7 +56,7 @@ define daemontools::service(
   file {"/etc/${name}/log/run":
     ensure  => present,
     mode    => '0755',
-    content => template("daemontools/log.erb"),
+    content => template('daemontools/log.erb'),
     require => File["/etc/${name}/log"],
     notify  => Service[$name],
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,18 @@
+{
+  "name": "jbussdieker-daemontools",
+  "version": "0.0.3",
+  "author": "Joshua B. Bussdieker",
+  "summary": "Daemontools Module",
+  "license": "Apache-2.0",
+  "source": "https://github.com/Ensighten/puppet-daemontools.git",
+  "dependencies": [],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
+    }
+  ]
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "jbussdieker-daemontools",
-  "version": "0.0.3",
+  "version": "0.2.0-ens",
   "author": "Joshua B. Bussdieker",
   "summary": "Daemontools Module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Backwards compatible fixes to allow this module to work under puppet 4.

See [here](https://docs.puppetlabs.com/puppet/latest/reference/experiments_future.html#check-the-mode-attribute-of-any-file-resources).
